### PR TITLE
修复CI故障

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,4 @@ jobs:
       - run: mkdocs gh-deploy --force
 # 我也不知道为什么失败了，调试1
 # 又TM失败了，调试2，这东西坑太TM大了，github的安全政策改了，原始文档也改了，但中文翻译没有
+# 前车之鉴：不可以开启gh-pages分支的强制推送保护

--- a/.github/workflows/mail.yml
+++ b/.github/workflows/mail.yml
@@ -1,21 +1,21 @@
-name: 'Notice Reviewers'
+#name: 'Notice Reviewers'
 
-on:
-  pull_request:
-    types: [opened, reopened]
+#on:
+#  pull_request:
+#    types: [opened, reopened]
 
-jobs:
-  bot:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Send mail'
-        uses: dawidd6/action-send-mail@master
-        with:
-          server_address: smtp.163.com
-          server_port: 465
-          username: ${{ secrets.MAIL_USERNAME }}
-          password: ${{ secrets.MAIL_PASSWORD }}
-          subject: A new PR
-          html_body: notice.txt
-          to: java_utils@outlook.com
-          from: GitHub Actions
+#jobs:
+#  bot:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: 'Send mail'
+#        uses: dawidd6/action-send-mail@master
+#        with:
+#          server_address: smtp.163.com
+#          server_port: 465
+#          username: ${{ secrets.MAIL_USERNAME }}
+#          password: ${{ secrets.MAIL_PASSWORD }}
+#          subject: A new PR
+#          html_body: notice.txt
+#          to: java_utils@outlook.com
+#          from: GitHub Actions


### PR DESCRIPTION
本次PR修复了以下CI故障
1. 自动部署GitHub Pages不生效（原因为开启分支强制推送保护）
2. 自动发送邮件不生效（全部注释掉，等待@BsoltB修复）